### PR TITLE
Support downloading the base language from OneSky

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ configure<OneSkyPluginExtension> {
     // has src/main/res/ as a default value,    
     // can be overriden with your custom path (optional)
     sourcePath = "path-to-your-string-values-directory"
+
+    // Determines if the plugin should download & replace the base language or not.
+    // defaults to false
+    downloadBaseLanguage = false
 }
 ```
 

--- a/plugin/src/main/java/co/brainly/onesky/OneSkyPlugin.kt
+++ b/plugin/src/main/java/co/brainly/onesky/OneSkyPlugin.kt
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.TestOnly
  * @property apiSecret API secret found on OneSky account's settings page
  * @property projectId OneSky's project id for syncing files with
  * @property sourceStringFiles list of files to be synced with OneSky
+ * @property downloadBaseLanguage Determines if the plugin should download & replace the base language or not
  */
 open class OneSkyPluginExtension(
     var verbose: Boolean = false,
@@ -22,7 +23,8 @@ open class OneSkyPluginExtension(
     var apiSecret: String = "",
     var projectId: Int = -1,
     var sourceStringFiles: List<String> = emptyList(),
-    var sourcePath: String = "src/main/res"
+    var sourcePath: String = "src/main/res",
+    var downloadBaseLanguage: Boolean = false
 ) {
     internal var oneSkyApiUrl: String = ONESKY_API_URL
 


### PR DESCRIPTION
Our current workflow has content editors making adjustments to the base language in OneSky and we are manually downloading and replacing the translation files in the project.

This PR adds an optional setting that will allow this plugin to download the base language.