### PR TITLE
Add support for multi-module projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: 
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build plugin
+      uses: gradle/gradle-build-action@v2.3.3
+      with:
+        arguments: build

--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,6 @@ proguard/
 
 *.iml
 
-#local gradle properties
-gradle.properties
-
 #captures from Android Studio (heap dumps, view hierarchy)
 captures/
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Plugin for downloading and uploading translations from <a href="https://www.ones
 </p>
 
 <p align="center">
-    <img src="https://img.shields.io/badge/version-1.3.0-blue.svg">
+    <img src="https://img.shields.io/badge/version-1.4.0-blue.svg"> <img src="https://github.com/brainly/onesky-gradle-plugin/actions/workflows/build.yml/badge.svg">
 </p>
+
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ configure<OneSkyPluginExtension> {
     moduleName = "my-feature"
 }
 ```
-will result in uploading `my-feature-strings.xml` to OneSky, so on next sync, my-feature-strings.xml will be downloaded, containing only translations for a given module.
+will result in uploading `my-feature-strings.xml` to OneSky, so on next sync, `my-feature-strings.xml` will be downloaded, containing only translations for a given module.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ configure<OneSkyPluginExtension> {
     // has src/main/res/ as a default value,    
     // can be overriden with your custom path (optional)
     sourcePath = "path-to-your-string-values-directory"
+    
+    // prefix set for translation files located in different Gradle modules
+    // which share the same OneSky project
+    // (optional, required for multi-module support)
+    moduleName = "avatar-picker"
 
     // Determines if the plugin should download & replace the base language or not.
     // defaults to false
@@ -38,11 +43,11 @@ configure<OneSkyPluginExtension> {
 
 ## Features
 
-| Task                 | Description                                                              |
-|----------------------|--------------------------------------------------------------------------|
+| Task                     | Description                                                           |
+|--------------------------|-----------------------------------------------------------------------|
 | **translationsProgress** | Displays translations progress for all languages                      |
 | **downloadTranslations** | Downloads all of available translations (including not finished ones) |
-| **uploadTranslations**  | Uploads base translation files |
+| **uploadTranslations**   | Uploads base translation files                                        |
 
 Add `-Pdeprecate-strings` if you would like to deprecate strings on OneSky which are not present in `sourceStringFiles`.
 
@@ -50,6 +55,29 @@ Add `-Pdeprecate-strings` if you would like to deprecate strings on OneSky which
 # deprecates removed strings on OneSky
 ./gradlew sample:uploadTranslations -Pdeprecate-strings
 ```
+
+### Multi-module support
+
+If you have a multi-module project and would like to:
+- use single OneSky project for all of them
+- AND keep translation files in their respective modules
+
+your choice is to either:
+- name every `strings.xml` file differently for every module, which seems tedious
+- OR use `moduleName` property in `OneSkyPluginExtension`
+
+`moduleName` property will automatically prefix your string files so they do not overlap on OneSky.
+
+Example:
+```kotlin
+// project-dir/my-feature-module/build.gradle.kts
+
+configure<OneSkyPluginExtension> {
+    moduleName = "my-feature"
+}
+```
+will result in uploading `my-feature-strings.xml` to OneSky, so on next sync, my-feature-strings.xml will be downloaded, containing only translations for a given module.
+
 ## Releasing
 
 See the release instructions [here](HOW_TO_RELEASE.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError

--- a/plugin/src/main/java/co/brainly/onesky/OneSkyPlugin.kt
+++ b/plugin/src/main/java/co/brainly/onesky/OneSkyPlugin.kt
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.TestOnly
  * @property projectId OneSky's project id for syncing files with
  * @property sourceStringFiles list of files to be synced with OneSky
  * @property downloadBaseLanguage Determines if the plugin should download & replace the base language or not
+ * @property moduleName appends a prefix to all [sourceStringFiles] for multi-module support, use null to disable
  */
 open class OneSkyPluginExtension(
     var verbose: Boolean = false,
@@ -24,7 +25,8 @@ open class OneSkyPluginExtension(
     var projectId: Int = -1,
     var sourceStringFiles: List<String> = emptyList(),
     var sourcePath: String = "src/main/res",
-    var downloadBaseLanguage: Boolean = false
+    var downloadBaseLanguage: Boolean = false,
+    var moduleName: String? = null
 ) {
     internal var oneSkyApiUrl: String = ONESKY_API_URL
 

--- a/plugin/src/main/java/co/brainly/onesky/client/OneSkyApiClient.kt
+++ b/plugin/src/main/java/co/brainly/onesky/client/OneSkyApiClient.kt
@@ -50,14 +50,25 @@ class OneSkyApiClient(
         return fetch(request)
     }
 
-    fun fetchTranslation(projectId: Int, sourceFile: String, language: Language): Result<String> {
+    fun fetchTranslation(
+        projectId: Int,
+        sourceFile: String,
+        language: Language,
+        fileNamePrefix: String? = null
+    ): Result<String> {
+        val sourceFileName = if (fileNamePrefix != null) {
+            "$fileNamePrefix-$sourceFile"
+        } else {
+            sourceFile
+        }
+
         val url = baseUrl.newBuilder()
             .addPathSegment("projects")
             .addPathSegment(projectId.toString())
             .addPathSegment("translations")
             .addAuthParams(apiKey, apiSecret)
             .addQueryParameter("locale", language.code)
-            .addQueryParameter("source_file_name", sourceFile)
+            .addQueryParameter("source_file_name", sourceFileName)
             .build()
 
         val request = Request.Builder()

--- a/plugin/src/main/java/co/brainly/onesky/client/OneSkyApiClient.kt
+++ b/plugin/src/main/java/co/brainly/onesky/client/OneSkyApiClient.kt
@@ -68,7 +68,12 @@ class OneSkyApiClient(
         return fetch(request)
     }
 
-    fun uploadTranslation(projectId: Int, file: File, deprecateStrings: Boolean): Result<String> {
+    fun uploadTranslation(
+        projectId: Int,
+        file: File,
+        deprecateStrings: Boolean,
+        fileNamePrefix: String? = null
+    ): Result<String> {
         val isKeepingAllStrings = if (deprecateStrings) {
             "false"
         } else {
@@ -84,9 +89,14 @@ class OneSkyApiClient(
             .addQueryParameter("is_keeping_all_strings", isKeepingAllStrings)
             .build()
 
+        val fileName = if (fileNamePrefix != null) {
+            "$fileNamePrefix-${file.name}"
+        } else {
+            file.name
+        }
         val body = MultipartBody.Builder(boundary = "onesky-gradle-plugin-file")
             .setType(MultipartBody.FORM)
-            .addFormDataPart("file", file.name, file.asRequestBody("application/octet-stream".toMediaTypeOrNull()))
+            .addFormDataPart("file", fileName, file.asRequestBody("application/octet-stream".toMediaTypeOrNull()))
             .build()
 
         val request = Request.Builder()

--- a/plugin/src/main/java/co/brainly/onesky/task/DownloadTranslationsTask.kt
+++ b/plugin/src/main/java/co/brainly/onesky/task/DownloadTranslationsTask.kt
@@ -23,6 +23,7 @@ open class DownloadTranslationsTask @Inject constructor(
     private val files = extension.sourceStringFiles
     private val sourcePath = extension.sourcePath
     private val downloadBaseLanguage = extension.downloadBaseLanguage
+    private val moduleName = extension.moduleName
 
     private val logger = LoggerFactory.getLogger("downloadTranslations")
     private val progressLogger by lazy {
@@ -59,7 +60,7 @@ open class DownloadTranslationsTask @Inject constructor(
                 progressLogger.progress(
                     "${language.code}: $filename (${languageIndex * files.size + fileIndex}/$totalFiles)"
                 )
-                val translation = client.fetchTranslation(projectId, filename, language)
+                val translation = client.fetchTranslation(projectId, filename, language, fileNamePrefix = moduleName)
                 translation.handle(
                     onSuccess = { saveTranslation(language, filename, it) },
                     onFailure = { reportTranslationFailure(language, filename, it) }

--- a/plugin/src/main/java/co/brainly/onesky/task/UploadTranslationTask.kt
+++ b/plugin/src/main/java/co/brainly/onesky/task/UploadTranslationTask.kt
@@ -21,6 +21,7 @@ open class UploadTranslationTask @Inject constructor(
     private val projectId = extension.projectId
     private val files = extension.sourceStringFiles
     private val sourcePath = extension.sourcePath
+    private val moduleName = extension.moduleName
 
     private val client = OneSkyApiClient(
         apiKey = extension.apiKey,
@@ -55,7 +56,8 @@ open class UploadTranslationTask @Inject constructor(
             val result = client.uploadTranslation(
                 projectId,
                 baseTranslationFile,
-                deprecateStrings = deprecateStrings
+                deprecateStrings = deprecateStrings,
+                fileNamePrefix = moduleName
             )
             result.handle(
                 onSuccess = { /*do nothing*/ },

--- a/plugin/src/main/java/co/brainly/onesky/task/UploadTranslationTask.kt
+++ b/plugin/src/main/java/co/brainly/onesky/task/UploadTranslationTask.kt
@@ -46,12 +46,10 @@ open class UploadTranslationTask @Inject constructor(
 
         files.forEachIndexed { index, filename ->
             progressLogger.progress(
-                "$filename (${index + 1}/${files.size})"
+                "${moduleName?.let { "($it) " } ?: ""}$filename (${index + 1}/${files.size})"
             )
             val valuesDir = project.androidResDir.resolve("values")
             val baseTranslationFile = File(valuesDir, filename)
-
-            logger.warn(baseTranslationFile.absolutePath)
 
             val result = client.uploadTranslation(
                 projectId,

--- a/plugin/src/test/java/co/brainly/onesky/client/OneSkyApiClientTest.kt
+++ b/plugin/src/test/java/co/brainly/onesky/client/OneSkyApiClientTest.kt
@@ -175,4 +175,42 @@ class OneSkyApiClientTest {
             request.body.readByteString().utf8()
         )
     }
+
+    @Test
+    fun `uploads a translation file with appended prefix`() {
+        val file = File.createTempFile("onesky", ".tmp")
+        file.writeText("Hello OneSky Gradle Plugin")
+
+        client.uploadTranslation(projectId, file, deprecateStrings = false, fileNamePrefix = "my-feature")
+
+        val request = server.takeRequest()
+
+        assertEquals(
+            "/projects/41994/files?api_key=my-api-key&timestamp=12" +
+                "&dev_hash=28dac32cc9ee8ab264d35087653be23e&file_format=ANDROID_XML&is_keeping_all_strings=true",
+            request.path
+        )
+
+        assertEquals(
+            "POST",
+            request.method
+        )
+
+        assertEquals(
+            """
+            --onesky-gradle-plugin-file
+            Content-Disposition: form-data; name="file"; filename="my-feature-${file.name}"
+            Content-Type: application/octet-stream
+            Content-Length: 26
+
+            Hello OneSky Gradle Plugin
+            --onesky-gradle-plugin-file--
+
+            """.trimIndent().replace(
+                "\n",
+                "\r\n"
+            ), // to avoid conflicts with OkHttp
+            request.body.readByteString().utf8()
+        )
+    }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId = "co.brainly.sample"
         minSdk = 21
-        targetSdk = 28
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
             android:allowBackup="true"
             android:label="Sample"
             android:supportsRtl="true">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
Adds support for multi-module projects which are keeping their translation files per-module and are using single OneSky project.

This is achievable without new plugin version, however this PR makes the entire process easier (there is no further need for manually using different file names)
