### PR TITLE
add a setting to restrict which languages get downloaded

### DIFF
--- a/plugin/src/main/java/co/brainly/onesky/OneSkyPlugin.kt
+++ b/plugin/src/main/java/co/brainly/onesky/OneSkyPlugin.kt
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.TestOnly
  * @property apiSecret API secret found on OneSky account's settings page
  * @property projectId OneSky's project id for syncing files with
  * @property sourceStringFiles list of files to be synced with OneSky
+ * @property downloadLanguages list of languages to be downloaded, an empty list will download all available languages
  * @property downloadBaseLanguage Determines if the plugin should download & replace the base language or not
  * @property moduleName appends a prefix to all [sourceStringFiles] for multi-module support, use null to disable
  */
@@ -25,6 +26,7 @@ open class OneSkyPluginExtension(
     var projectId: Int = -1,
     var sourceStringFiles: List<String> = emptyList(),
     var sourcePath: String = "src/main/res",
+    var downloadLanguages: List<String> = emptyList(),
     var downloadBaseLanguage: Boolean = false,
     var moduleName: String? = null
 ) {

--- a/plugin/src/main/java/co/brainly/onesky/task/DownloadTranslationsTask.kt
+++ b/plugin/src/main/java/co/brainly/onesky/task/DownloadTranslationsTask.kt
@@ -22,6 +22,7 @@ open class DownloadTranslationsTask @Inject constructor(
     private val projectId = extension.projectId
     private val files = extension.sourceStringFiles
     private val sourcePath = extension.sourcePath
+    private val downloadLanguages = extension.downloadLanguages
     private val downloadBaseLanguage = extension.downloadBaseLanguage
     private val moduleName = extension.moduleName
 
@@ -52,6 +53,7 @@ open class DownloadTranslationsTask @Inject constructor(
 
     private fun downloadLanguages(languageListResponse: LanguageListResponse) {
         val languages = languageListResponse.data
+            .filter { downloadLanguages.isEmpty() || it.code in downloadLanguages }
             .filter { downloadBaseLanguage || !it.is_base_language }
 
         val totalFiles = languages.size * files.size


### PR DESCRIPTION
We currently store several partial translations in our OneSky project that we don't want to download. This PR adds an optional setting that allows the user to specify which languages to download.
